### PR TITLE
Cleanup and implemented PR #33 path separator fix

### DIFF
--- a/ValheimPlus/Configurations/ConfigurationExtra.cs
+++ b/ValheimPlus/Configurations/ConfigurationExtra.cs
@@ -31,8 +31,8 @@ namespace ValheimPlus.Configurations
             return Settings.CreateMD5(serialized);
         }
 
-        static string ConfigYamlPath = Path.GetDirectoryName(Paths.BepInExConfigPath) + "\\valheim_plus.yml";
-        static string ConfigIniPath = Path.GetDirectoryName(Paths.BepInExConfigPath) + "\\valheim_plus.cfg";
+        static string ConfigYamlPath = Path.GetDirectoryName(Paths.BepInExConfigPath) + Path.DirectorySeparatorChar + "valheim_plus.yml";
+        static string ConfigIniPath = Path.GetDirectoryName(Paths.BepInExConfigPath) + Path.DirectorySeparatorChar + "valheim_plus.cfg";
 
         public static bool LoadSettings()
         {

--- a/setupDependencies.ps1
+++ b/setupDependencies.ps1
@@ -1,8 +1,0 @@
-$steamregkey="Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam"
-$keyname="InstallPath"
-
-$valheimId=""
-
-$SteamPath=Get-ItemProperty -Path $steamregkey -Name $keyname | Select-Object -ExpandProperty $keyname
-
-Write-Output $SteamPath


### PR DESCRIPTION
I just noticed there was a file included that shouldn't have been, and also that PR #33 wasn't applied to the new config setup. This fixes both